### PR TITLE
Enable direct access grants for cli client

### DIFF
--- a/roles/utility/templates/rhbk_client_cli.json.j2
+++ b/roles/utility/templates/rhbk_client_cli.json.j2
@@ -5,7 +5,7 @@
   "publicClient": false,
   "implicitFlowEnabled": false,
   "standardFlowEnabled": false,
-  "directAccessGrantsEnabled": false,
+  "directAccessGrantsEnabled": true,
   "serviceAccountsEnabled": true,
   "fullScopeAllowed": true,
   "defaultClientScopes": [


### PR DESCRIPTION
To demonstrate usage of the Trustify API to upload sample SBOMs.